### PR TITLE
Incorporate aliased queries into AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 *.iml
 target
+
+.DS_Store

--- a/src/main/java/edu/phema/transform/ElmTransformer.java
+++ b/src/main/java/edu/phema/transform/ElmTransformer.java
@@ -10,10 +10,11 @@ import org.jgrapht.graph.SimpleGraph;
 public class ElmTransformer {
 
     /**
-     * Given an ELM library, and a specific expression definition within that library, resolved references be inlining
-     * expression references. The result is an ELM tree will all references already resolved.
+     * Given an ELM library, and a specific expression definition within that library, resolve references by inlining
+     * expression references. The result is an ELM tree with all references already resolved.
      *
-     * @param expressionDef The express to use as the root of the tree
+     * @param library The library from which all expressions and references can be found
+     * @param expressionDef The expression to use as the root of the tree
      * @return
      */
     public void resolveReferences(Library library, ExpressionDef expressionDef) throws ElmTransformerException {

--- a/src/main/java/edu/phema/transform/visiting/ElmGraphTransformationVisitor.java
+++ b/src/main/java/edu/phema/transform/visiting/ElmGraphTransformationVisitor.java
@@ -8,15 +8,11 @@ public class ElmGraphTransformationVisitor extends ElmBaseStatementPostOrderTran
         super(true);
     }
 
-    public String buildLabelForQuery(Query query) {
-        return "Query";
-    }
-
     public String getLabel(Expression elm) {
         if (elm instanceof Literal) {
             return ((Literal) elm).getValue();
         } else if (elm instanceof Query) {
-            return buildLabelForQuery((Query) elm);
+            return "Query";
         } else if (elm instanceof Retrieve) {
           return String.format("%s in '%s'", ((Retrieve) elm).getDataType().getLocalPart(), ((ValueSetRef) ((Retrieve) elm).getCodes()).getName());
         } else if (elm instanceof Property) {
@@ -46,8 +42,20 @@ public class ElmGraphTransformationVisitor extends ElmBaseStatementPostOrderTran
     }
 
     @Override
+    public Void visitAliasedQuerySource(AliasedQuerySource elm, ElmGraphTransformationContext context) {
+      context.addChild(elm.getTrackerId().hashCode(), elm.getAlias());
+      super.visitAliasedQuerySource(elm, context);
+      return null;
+    }
+
+    @Override
     public Void visitRelationshipClause(RelationshipClause elm, ElmGraphTransformationContext context) {
-      context.addChild(elm.getTrackerId().hashCode(), elm.getClass().getSimpleName());
+      String label = elm.getClass().getSimpleName();
+      String alias = elm.getAlias();
+      if (alias != null && !alias.trim().equals("")) {
+        label = String.format("%s %s", label, alias);
+      }
+      context.addChild(elm.getTrackerId().hashCode(), label);
       super.visitRelationshipClause(elm, context);
       return null;
     }

--- a/src/main/java/edu/phema/visiting/ElmBaseStatementPostOrderTransformationVisitor.java
+++ b/src/main/java/edu/phema/visiting/ElmBaseStatementPostOrderTransformationVisitor.java
@@ -1094,11 +1094,11 @@ public class ElmBaseStatementPostOrderTransformationVisitor<T, C extends ElmBase
     public T visitAliasedQuerySource(AliasedQuerySource elm, C context) {
         debug("visitAliasedQuerySource");
 
-        context.push(elm);
+        //context.push(elm);
 
         this.visitExpression(elm.getExpression(), context);
 
-        context.pop();
+        //context.pop();
 
         return super.visitAliasedQuerySource(elm, context);
     }
@@ -1112,6 +1112,14 @@ public class ElmBaseStatementPostOrderTransformationVisitor<T, C extends ElmBase
     @Override
     public T visitRelationshipClause(RelationshipClause elm, C context) {
         debug("visitRelationshipClause");
+
+        context.push(elm);
+
+        this.visitExpression(elm.getSuchThat(), context);
+        this.visitExpression(elm.getExpression(), context);
+
+        context.pop();
+
         return super.visitRelationshipClause(elm, context);
     }
 
@@ -1167,38 +1175,14 @@ public class ElmBaseStatementPostOrderTransformationVisitor<T, C extends ElmBase
     public T visitQuery(Query elm, C context) {
         debug("visitQuery");
 
-        /*
-            @XmlElement(namespace = "urn:hl7-org:elm:r1", required = true)
-    protected List<AliasedQuerySource> source;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected List<LetClause> let;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected List<RelationshipClause> relationship;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected Expression where;
-    @XmlElement(name = "return", namespace = "urn:hl7-org:elm:r1")
-    protected ReturnClause _return;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected SortClause sort;    @XmlElement(namespace = "urn:hl7-org:elm:r1", required = true)
-    protected List<AliasedQuerySource> source;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected List<LetClause> let;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected List<RelationshipClause> relationship;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected Expression where;
-    @XmlElement(name = "return", namespace = "urn:hl7-org:elm:r1")
-    protected ReturnClause _return;
-    @XmlElement(namespace = "urn:hl7-org:elm:r1")
-    protected SortClause sort;
-         */
         context.push(elm);
 
         elm.getSource().stream().forEach(s -> this.visitAliasedQuerySource(s, context));
+        elm.getLet().stream().forEach(l -> this.visitLetClause(l, context));
+        elm.getRelationship().stream().forEach(r -> this.visitRelationshipClause(r, context));
+        this.visitExpression(elm.getWhere(), context);
 
         context.pop();
-
-
         return super.visitQuery(elm, context);
     }
 

--- a/src/main/java/edu/phema/visiting/ElmBaseStatementPostOrderTransformationVisitor.java
+++ b/src/main/java/edu/phema/visiting/ElmBaseStatementPostOrderTransformationVisitor.java
@@ -1094,11 +1094,11 @@ public class ElmBaseStatementPostOrderTransformationVisitor<T, C extends ElmBase
     public T visitAliasedQuerySource(AliasedQuerySource elm, C context) {
         debug("visitAliasedQuerySource");
 
-        //context.push(elm);
+        context.push(elm);
 
         this.visitExpression(elm.getExpression(), context);
 
-        //context.pop();
+        context.pop();
 
         return super.visitAliasedQuerySource(elm, context);
     }


### PR DESCRIPTION
Modify how we build the context hierarchy so that we are including the aliased query directly within the tree instead of separate top-level nodes in the graph.